### PR TITLE
Add config option "knobSize"

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ max                  | number | 360           | largest value
 data                 | array  | []            | array of data to be spread in 360°
 dataIndex            | number | 0             | initially place knob at a certain value in the array
 knobColor            | string | #4e63ea       | knob color
+knobSize             | number | 32            | knob size
 hideKnob             | boolean| false         | hide knob
 knobDraggable        | boolean| true          | knob not draggable
 knobPosition         | string | top           | knob's 0 position to be **top**, **right**, **bottom** or **left**

--- a/src/App.js
+++ b/src/App.js
@@ -64,12 +64,13 @@ const App = () => {
 					labelColor='#005a58'
 					labelBottom={true}
 					knobColor='#005a58'
+					knobSize={72}
 					progressColorFrom='#00bfbd'
 					progressColorTo='#009c9a'
 					progressSize={24}
 					trackColor='#eeeeee'
 					trackSize={24}>
-					<DragIcon x='9' y='9' width='18px' height='18px' />
+					<DragIcon x='22' y='22' width='28px' height='28px' />
 				</CircularSlider>
 			</div>
 			<pre className={styles.pre}>
@@ -87,13 +88,14 @@ const App = () => {
     labelColor="#005a58"
     labelBottom={true}
     knobColor="#005a58"
+    knobSize={72}
     progressColorFrom="#00bfbd"
     progressColorTo="#005a58"
     progressSize={24}
     trackColor="#eeeeee"
     trackSize={24}
 >
-    <DragIcon x="9" y="8" width="18px" height="18px" />
+    <DragIcon x='22' y='22' width='28px' height='28px' />
 </CircularSlider>`}
 			</pre>
 			<h3 className={styles.h3}>

--- a/src/CircularSlider/index.js
+++ b/src/CircularSlider/index.js
@@ -53,6 +53,7 @@ const CircularSlider = ({
         min = 0,
         max = 360,
         knobColor = '#4e63ea',
+        knobSize = 36,
         knobPosition = 'top',
         labelColor = '#272b77',
         labelBottom = false,
@@ -245,6 +246,7 @@ const CircularSlider = ({
                 <Knob
                     isDragging={state.isDragging}
                     knobPosition={{ x: state.knob.x, y: state.knob.y }}
+                    knobSize={knobSize}
                     knobColor={knobColor}
                     trackSize={trackSize}
                     hideKnob={hideKnob}

--- a/src/Knob/index.js
+++ b/src/Knob/index.js
@@ -6,8 +6,7 @@ const Knob = ({
 	isDragging,
 	knobPosition,
 	knobColor,
-	knobRadius = 12,
-	knobSize = 36,
+	knobSize,
 	hideKnob,
 	onMouseDown,
 	trackSize,
@@ -45,11 +44,14 @@ const Knob = ({
 
 	const defaultKnobIcon = () => {
 		return (
-			<>
+			<svg
+				width={`${knobSize}px`}
+				height={`${knobSize}px`}
+				viewBox={`0 0 36 36`}>
 				<rect fill='#FFFFFF' x='14' y='14' width='8' height='1' />
 				<rect fill='#FFFFFF' x='14' y='17' width='8' height='1' />
 				<rect fill='#FFFFFF' x='14' y='20' width='8' height='1' />
-			</>
+			</svg>
 		);
 	};
 
@@ -83,7 +85,7 @@ const Knob = ({
 					stroke='none'
 					cx={knobSize / 2}
 					cy={knobSize / 2}
-					r={knobRadius}
+					r={(knobSize * 2 / 3) / 2}
 				/>
 				{children ? customKnobIcon() : defaultKnobIcon()}
 			</svg>


### PR DESCRIPTION
Thanks for this beautiful slider. 👍  I am using it in my current project, but I need to change the knob size. So I hope this PR is also in your interest (see #19).

Add config option to change knob size.

- Default size of the knob is still the same (36px)
- Pulse size is now relative to knob size (with the same size for the default knob size)
- Default icon will scale with knob size
- Second example uses bigger knob size for demonstration

Notes:
- custom icons still need explicit x/y and size values and do not scale automatically