### PR TITLE
Keep only alphanumerical characters in label used by SVG gradient id

### DIFF
--- a/src/CircularSlider/index.js
+++ b/src/CircularSlider/index.js
@@ -225,7 +225,7 @@ const CircularSlider = ({
     useEventListener(SLIDER_EVENT.MOVE, onMouseMove);
     useEventListener(SLIDER_EVENT.UP, onMouseUp);
 
-    const sanitizedLabel = label.replace(/[^A-Za-z0-9]+/g, " ").split(" ").join("");
+    const sanitizedLabel = label.replace(/[\W_]/g, "_");
 
     return (
         <div style={{...styles.circularSlider, ...(state.mounted && styles.mounted)}} ref={circularSlider}>

--- a/src/CircularSlider/index.js
+++ b/src/CircularSlider/index.js
@@ -225,11 +225,13 @@ const CircularSlider = ({
     useEventListener(SLIDER_EVENT.MOVE, onMouseMove);
     useEventListener(SLIDER_EVENT.UP, onMouseUp);
 
+    const sanitizedLabel = label.replace(/[^A-Za-z0-9]+/g, " ").split(" ").join("");
+
     return (
         <div style={{...styles.circularSlider, ...(state.mounted && styles.mounted)}} ref={circularSlider}>
             <Svg
                 width={width}
-                label={label.split(" ").join("")}
+                label={sanitizedLabel}
                 direction={direction}
                 strokeDasharray={state.dashFullArray}
                 strokeDashoffset={state.dashFullOffset}


### PR DESCRIPTION
I have found a sneaky case that prevents the gradient in the SVG to work at all.
**To reproduce use any of the examples and pass any label containing a single quote, e.g. "I'd like to borrow".**

Since the label is being used as the id in the SVG, passing it without sanitizing special characters breaks the gradient feature.
This PR proposes a change that takes the label prop and creates a sanitized copy before passing it down to the SVG component.