### PR TITLE
Continuous mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ width                | number | 280           | width of the slider
 direction            | number | 1             | clockwise (**1**) or anticlockwise (**-1**)
 min                  | number | 0             | smallest value
 max                  | number | 360           | largest value
+initialValue         | number | 0             | set an initial value for the label
 data                 | array  | []            | array of data to be spread in 360°
 dataIndex            | number | 0             | initially place knob at a certain value in the array
 knobColor            | string | #4e63ea       | knob color
@@ -90,6 +91,10 @@ trackSize            | number | 8             | background track size
 trackDraggable       | boolean| false         | make the track draggable
 onChange             | func   | value => {}   | returns label value
 isDragging           | func   | value => {}   | returns isDragging value
+continuous           | object | ...           | apply settings to enable continuous mode
+continuous.enabled   | boolean| false         | whether continuous mode is enabled
+continuous.clicks    | number | 120           | the amount of clicks per loop cycle
+continuous.interval  | number | 1             | the amount to increment/decrement with each click
 
 ## 
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,12 +2,19 @@
 import React from 'react';
 declare module '@fseehawer/react-circular-slider' {
 
+  interface Continuous {
+    enabled: boolean;
+    clicks: number;
+    interval: number;
+  }
+
   export interface CircularSliderProps {
     label?: string;
     width?: number;
     direction?: number;
     min?: number;
     max?: number;
+    initialValue?: number;
     knobColor?: string;
     knobPosition?: string;
     knobSize?: number;
@@ -34,6 +41,7 @@ declare module '@fseehawer/react-circular-slider' {
     onChange?: Function;
     children?: React.ReactNode;
     isDragging?: Function;
+    continuous?: Continuous;
   }
 
   const CircularSlider: React.FC<CircularSliderProps>;

--- a/src/App.js
+++ b/src/App.js
@@ -162,6 +162,43 @@ import { ReactComponent as EmojiIcon } from './assets/emoji.svg';
     <EmojiIcon x="9" y="9" width="18px" height="18px" />
 </CircularSlider>`}
 			</pre>
+			<h3 style={styles.h3}>
+				Here continuous mode is enabled, making the dial behave like an iPod click wheel.
+				You can click anywhere on the wheel to start the interaction and move 
+				the dial round infinitely, up and down to the max/min values.
+			</h3>
+			<div style={styles.slider}>
+				<CircularSlider
+				    min={0}
+					max={360}
+					knobPosition='right'
+					appendToValue='°'
+					valueFontSize='4rem'
+					trackColor="#eeeeee"
+					trackDraggable={true}
+					continuous={{
+						enabled: true,
+						clicks: 100,
+						increment: 1,
+					}}
+				/>
+			</div>
+			<pre className={styles.pre}>
+				{`<CircularSlider
+    min={0}
+    max={360}
+    knobPosition="right"
+    appendToValue="°"
+    valueFontSize="4rem"
+    trackColor="#eeeeee"
+	trackDraggable={true}
+	continuous={{
+		enabled: true,
+		clicks: 100
+		increment: 1,
+	}}
+/>`}
+			</pre>
 			<br />
 			<hr />
 			<br />

--- a/src/Svg/index.js
+++ b/src/Svg/index.js
@@ -15,7 +15,8 @@ const Svg = ({
          svgFullPath,
          radiansOffset,
          progressLineCap,
-         onMouseDown
+         onMouseDown,
+         isDragging
      }) => {
     const circleRef = useRef(null)
     const styles = ({
@@ -52,7 +53,8 @@ const Svg = ({
           Math.pow(mouseX - circleCenterX, 2) + Math.pow(mouseY - circleCenterY, 2)
         );
 
-        if (distance < (circleBounds.width / 2) - trackSize) {
+        const threshold = (circleBounds.width / isDragging ? 4 : 2) - trackSize
+        if (distance < threshold) {
             return
         }
         


### PR DESCRIPTION
Hi again,

This PR builds on https://github.com/fseehawer/react-circular-slider/pull/73 to add "continuous mode"

- When enabled this allows the slider to be rotated infinitely with the value going up to the maximum and down to the minimum
- I've added a demo of this to the homepage and docs about the new props and how to use them
- I've also added a new `initialValue` prop 

Let me know what you think 🙂