### PR TITLE
fix negative direction and knobOffset

### DIFF
--- a/src/CircularSlider/index.js
+++ b/src/CircularSlider/index.js
@@ -220,7 +220,7 @@ const CircularSlider = ({
 
                 return setKnobPosition(radians+(offset*getSliderRotation(direction)));
             }
-            setKnobPosition(-(knobOffset[state.knobPosition]*getSliderRotation(direction))+(offset*getSliderRotation(direction)));
+            setKnobPosition(-(knobOffset[state.knobPosition])+(offset*getSliderRotation(direction)));
         }
 
         // eslint-disable-next-line


### PR DESCRIPTION
fix issue https://github.com/fseehawer/react-circular-slider/issues/75

the problem was to apply the factor -1 from anticlockwise direction to the `knobOffset[state.knobPosition]` in `setKnobPosition()` parameter. Direction should not interfere with the knob initial position.

how to test it : run the app and comment line 38 in App.js, the behavior should be normal as compared to broken behavior pointed out in the issue ([see codesanbox](https://codesandbox.io/s/xenodochial-aj-n0blww?file=/src/App.js))

I didn't dig the whole app code, so please feel free to evaluate if this modification can produce undesirable side effects.

