### PR TITLE
add option to hide the slightly transparent ring around the knob

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ dataIndex                  | number          | 0             | initially place k
 knobColor                  | string          | #4e63ea       | knob color
 knobSize                   | number          | 32            | knob size
 hideKnob                   | boolean         | false         | hide knob
+hideKnobRing               | boolean         | false         | hide the slightly transparent ring around knob
 knobDraggable              | boolean         | true          | knob draggable
 knobPosition               | string or number| top           | knob's 0 position as an angle or **top**, **right**, **bottom**, **left**
 label                      | string          | ANGLE         | label

--- a/src/CircularSlider/index.js
+++ b/src/CircularSlider/index.js
@@ -70,6 +70,7 @@ const CircularSlider = ({
         verticalOffset = '1.5rem',
         hideLabelValue = false,
         hideKnob = false,
+        hideKnobRing = false,
         knobDraggable = true,
         progressColorFrom = '#80C3F3',
         progressColorTo = '#4990E2',
@@ -349,6 +350,7 @@ const CircularSlider = ({
                 knobColor={knobColor}
                 trackSize={trackSize}
                 hideKnob={hideKnob}
+                hideKnobRing={hideKnobRing}
                 knobDraggable={knobDraggable}
                 onMouseDown={onMouseDown}
             >

--- a/src/Knob/index.js
+++ b/src/Knob/index.js
@@ -8,6 +8,7 @@ const Knob = ({
 	knobColor,
 	knobSize,
 	hideKnob,
+	hideKnobRing,
 	knobDraggable,
 	onMouseDown,
 	trackSize,
@@ -62,15 +63,17 @@ const Knob = ({
 				width={`${knobSize}px`}
 				height={`${knobSize}px`}
 				viewBox={`0 0 ${knobSize} ${knobSize}`}>
-				<circle
-					style={{ ...styles.animation, ...(isDragging && styles.pause) }}
-					fill={knobColor}
-					fillOpacity='0.2'
-					stroke='none'
-					cx={knobSize / 2}
-					cy={knobSize / 2}
-					r={knobSize / 2}
-				/>
+				{!hideKnobRing && (
+					<circle
+						style={{ ...styles.animation, ...(isDragging && styles.pause) }}
+						fill={knobColor}
+						fillOpacity='0.2'
+						stroke='none'
+						cx={knobSize / 2}
+						cy={knobSize / 2}
+						r={knobSize / 2}
+					/>
+				)}
 				<circle
 					fill={knobColor}
 					stroke='none'


### PR DESCRIPTION
It would be nice to be able to disable the transparent ring around the knob so it appears more flat. This is a simple PR to add a field/setting for this.

Let me know @fseehawer if there is a reason this should not be added.